### PR TITLE
Potential fix for code scanning alert no. 1: User-controlled data in arithmetic expression

### DIFF
--- a/src/main/java/se/sundsvall/simulatorserver/api/SimulatorServerController.java
+++ b/src/main/java/se/sundsvall/simulatorserver/api/SimulatorServerController.java
@@ -61,7 +61,13 @@ public class SimulatorServerController {
 
 		Optional.ofNullable(sortSize)
 			.ifPresent(size -> {
-				final List<String> result = IntStream.range(0, size * 10000)
+				// Validate size to prevent overflow and negative values
+				if (size < 0 || size > 100) {
+					LOGGER.warn("Invalid sortSize value: {}. Must be between 0 and 100.", size);
+					return;
+				}
+				final int listSize = size * 10000;
+				final List<String> result = IntStream.range(0, listSize)
 					.mapToObj(i -> UUID.randomUUID().toString())
 					.sorted()
 					.toList();


### PR DESCRIPTION
Potential fix for [https://github.com/Sundsvallskommun/api-service-simulator-server/security/code-scanning/1](https://github.com/Sundsvallskommun/api-service-simulator-server/security/code-scanning/1)

To fix the problem, we should ensure that the arithmetic operation `size * 10000` cannot overflow. The best way is to validate the value of `size` before performing the multiplication, ensuring it is within a safe range. Since the code already uses `@Max(100)`, we should add an explicit check in the code to ensure `size` is not negative and does not exceed a safe maximum (e.g., 100), and that the multiplication will not overflow. If the value is invalid, we can log a warning and skip the operation or throw an exception. The change should be made in the block starting at line 62, where the `size` is used.

No new imports are needed, as all required classes are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
